### PR TITLE
Correct TimeStep method

### DIFF
--- a/src/BasicModelInterface/BasicModelInterfaceLibrary.cs
+++ b/src/BasicModelInterface/BasicModelInterfaceLibrary.cs
@@ -69,7 +69,7 @@ namespace BasicModelInterface
             {
                 var dt = 0.0;
                 lib.get_time_step(ref dt);
-                return new TimeSpan(0, 0, 0, (int)dt, (int)(dt * 0.001));
+                return new TimeSpan(0, 0, 0, 0, (int)(dt * 1000));
             }
         }
 

--- a/src/BasicModelInterface/BasicModelInterfaceLibrary.cs
+++ b/src/BasicModelInterface/BasicModelInterfaceLibrary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -69,7 +69,7 @@ namespace BasicModelInterface
             {
                 var dt = 0.0;
                 lib.get_time_step(ref dt);
-                return new TimeSpan(0, 0, 0, (int)dt, (int)(dt * 0.001));
+                return new TimeSpan(0, 0, 0, 0, (int)(dt * 1000));
             }
         }
 

--- a/src/BasicModelInterface/BasicModelInterfaceLibrary.cs
+++ b/src/BasicModelInterface/BasicModelInterfaceLibrary.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -69,7 +69,7 @@ namespace BasicModelInterface
             {
                 var dt = 0.0;
                 lib.get_time_step(ref dt);
-                return new TimeSpan(0, 0, 0, 0, (int)(dt * 1000));
+                return new TimeSpan(0, 0, 0, (int)dt, (int)(dt * 0.001));
             }
         }
 


### PR DESCRIPTION
Tom Evans (NIWA) noticed that the TimeStep method returns the wrong value. The time step dt obtained from the model is currently applied both as seconds and divided by 1000 as milliseconds. This looks wrong hence the patch.

A bit of struggle with the invisible encoding tagon the first line. Accidentally removed initially, but it's unchanged now.